### PR TITLE
make load adress and payload type selectable from the `make` command itself

### DIFF
--- a/exploit/Makefile
+++ b/exploit/Makefile
@@ -2,15 +2,11 @@
 #alexparrado (2020)
 
 #Choose paylad you want 
-PAYLOAD=launcher-keys
+PAYLOAD ?= launcher-keys
 
 
 #OpenTuna load address
-LOADADDR  = 0x20c020c0
-
-
-
-
+LOADADDR  ?= 0x20c020c0
 
 
 
@@ -22,10 +18,8 @@ EE_OBJS = main.o   payload_elf.o
 EE_LDFLAGS +=  -nostartfiles  -Wl,-Ttext -Wl,$(LOADADDR)   -Wl,--gc-sections 
 EE_CFLAGS=-Os 
 
-
 all:
 	$(MAKE) $(EE_BIN_RAW) 
-
 
 payload_elf.s: 
 	$(MAKE) -C ../$(PAYLOAD)/
@@ -35,9 +29,6 @@ clean:
 	$(MAKE) -C ../$(PAYLOAD)/ clean
 	rm -f *.elf *.o *.s *.bin
 
-
-			
-
 $(EE_BIN_STRIPPED): $(EE_BIN)
 	$(EE_STRIP) -s -R .comment -R .gnu.version --strip-unneeded -o $@ $<
 
@@ -45,9 +36,5 @@ $(EE_BIN_STRIPPED): $(EE_BIN)
 $(EE_BIN_RAW): $(EE_BIN_STRIPPED)
 	$(EE_OBJCOPY) -O binary -v $< $@ 
 
-
-
-	
 include Makefile.pref
 include Makefile.eeglobal
-


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description


For example
do
```
make PAYLOAD=launcher-foobar
```

and project builds on `launcher-foobar` without modifying makefile